### PR TITLE
Fixed dependencies problem with mdx_grid package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setup(
         'Topic :: Text Processing :: Markup :: HTML',
     ],
     dependency_links=[
-        'https://github.com/dreikanter/markdown-grid/'
-        'tarball/master#egg=mdx_grid'
+        'https://github.com/dreikanter/markdown-grid/tarball/master#egg=mdx_grid'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,6 @@ setup(
         'Topic :: Text Processing :: Markup :: HTML',
     ],
     dependency_links=[
-        'https://github.com/dreikanter/markdown-grid/tarball/master#egg=mdx_grid'
+        'https://github.com/dreikanter/markdown-grid/tarball/master#egg=mdx_grid-0.2.2'
     ],
 )


### PR DESCRIPTION
pip behavior has changed and the current `dependency_links` does not work anymore. Also since dependency_links has been deprecated in latest version of pip (with Python 3.5), you also need to specify `--process-dependency-links` in command line argument to install it, e.g.:

`pip install -e git+git://github.com/dreikanter/public-static#egg=public-static --process-dependency-links`